### PR TITLE
Incorrect dependency

### DIFF
--- a/magento2/app/code/Mobilpay/Credit/Block/Redirect.php
+++ b/magento2/app/code/Mobilpay/Credit/Block/Redirect.php
@@ -15,19 +15,15 @@ class Redirect extends \Magento\Framework\View\Element\Template
     protected $_resource;
 
     public function __construct(\Magento\Framework\View\Element\Template\Context $context,
-                                \Magento\Store\Model\StoreManagerInterface $storeManager,
                                 \Magento\Checkout\Model\Session $session,
                                 \Magento\Framework\Module\Dir\Reader $reader,
-                                \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
                                 \Magento\Framework\App\ResourceConnection $resource,
                                 \Magento\Sales\Model\Order $orderFactory,
                                 array $data)
     {
         $this->_resource = $resource;
         $this->_checkoutSession = $session;
-        $this->_storeManager = $storeManager;
         $this->_moduleDirReader = $reader;
-        $this->_scopeConfig = $scopeConfig;
         $this->_orderFactory = $orderFactory;
         parent::__construct($context, $data);
     }


### PR DESCRIPTION
Those two dependencies are not needed because they exist in the current scope. If you to here Magento/Framework/View/Element/AbstractBlock.php and Magento/Framework/View/Element/Template.php you can see that those exist already. If you set the magento mode to production and turn on compilation, those extra dependencies result in an error:
```Mobilpay\Credit\Block\Redirect
        Incorrect dependency in class Mobilpay\Credit\Block\Redirect in public_html/app/code/Mobilpay/Credit/Block/Redirect.php
\Magento\Store\Model\StoreManagerInterface already exists in context object
\Magento\Framework\App\Config\ScopeConfigInterface already exists in context object```