### PR TITLE
Incorrect dependency

### DIFF
--- a/magento2/app/code/Mobilpay/Credit/Controller/Cc/Success.php
+++ b/magento2/app/code/Mobilpay/Credit/Controller/Cc/Success.php
@@ -10,13 +10,11 @@ class Success extends \Magento\Framework\App\Action\Action
     protected $_messageManager;
     public function __construct(Context $context,
                                 \Magento\Framework\View\Result\PageFactory $resultPageFactory,
-                                \Magento\Framework\Message\ManagerInterface $messageManager,
                                 \Magento\Sales\Model\Order $orderFactory
     )
     {
         $this->_orderFactory = $orderFactory;
         $this->resultPateFactory = $resultPageFactory;
-        $this->_messageManager = $messageManager;
         parent::__construct($context);
     }
     /**


### PR DESCRIPTION
Those two dependencies are not needed because they exist in the current scope. Check the extended class.

If you set the magento mode to production and turn on compilation, those extra dependencies result in an error:
``` Incorrect dependency in class Mobilpay\Credit\Controller\Cc\Success in public_html/app/code/Mobilpay/Credit/Controller/Cc/Success.php
\Magento\Framework\Message\ManagerInterface already exists in context object```