### PR TITLE
Orderfactory->load instead of loadByIncrementId

### DIFF
--- a/magento2/app/code/Mobilpay/Credit/Controller/Cc/Ipn.php
+++ b/magento2/app/code/Mobilpay/Credit/Controller/Cc/Ipn.php
@@ -70,7 +70,7 @@ class Ipn extends \Magento\Framework\App\Action\Action
         $this->_objPmReq = $objPmReq;
         $order_id = $objPmReq->orderId;
 
-        $this->_order = $this->_orderFactory->loadByIncrementId((int)$order_id);
+        $this->_order = $this->_orderFactory->load((int)$order_id);
 
         $this->_newOrderStatus = 'pending';
 


### PR DESCRIPTION
In order to get the right order, we must use load (which loads by entity_id), not loadByIncrementId.